### PR TITLE
change: submenu and settings page titles

### DIFF
--- a/Functions/SettingsPage.php
+++ b/Functions/SettingsPage.php
@@ -121,8 +121,8 @@ class SettingsPage {
 		foreach ( $external_plugins as $plugin_slug => $plugin_data ) {
 			\add_submenu_page(
 				'block-a11y-checks',
-				$plugin_data['name'] . ' ' . \esc_html__( 'Checks', 'block-accessibility-checks' ),
-				$plugin_data['name'] . ' ' . \esc_html__( 'Checks', 'block-accessibility-checks' ),
+				$plugin_data['name'],
+				$plugin_data['name'],
 				'manage_options',
 				'block-a11y-checks-' . $plugin_slug,
 				array( $this, 'external_plugin_settings_page' )
@@ -554,7 +554,7 @@ class SettingsPage {
 		$option_name  = 'block_checks_external_' . $plugin_slug;
 
 		echo '<div class="block-a11y-checks-settings">' . "\n";
-		echo '<h1>' . \esc_html( $plugin_data['name'] . ' ' . \__( 'Checks', 'block-accessibility-checks' ) ) . '</h1>' . "\n";
+		echo '<h1>' . \esc_html( $plugin_data['name'] ) . '</h1>' . "\n";
 		echo '<form class="block-a11y-checks-settings-form" action="options.php" method="post">' . "\n";
 		echo '<div class="block-a11y-checks-settings-grid">';
 


### PR DESCRIPTION
# Pull Request

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New accessibility check
- [ ] 🔌 New developer API feature
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ♿ Accessibility improvement
- [ ] 💥 Breaking change

## Related Issues

Related issue(s): #{add issue}

## Changes Made

<!-- List the main changes -->

- 
- 

## Testing

**Environment:**
- WordPress Version:
- Browser(s) tested:

**Test Cases:** _(check what applies to your change)_

**For new accessibility checks:**
- [ ] Tested error state (red border/message)
- [ ] Tested warning state (yellow border/message)
- [ ] Tested valid state (no indicators)
- [ ] Publishing prevention works (for errors)

**For updated accessibility checks:**
- [ ] Existing functionality still works
- [ ] New behavior works as expected
- [ ] No regressions in other blocks

**For new developer API features:**
- [ ] API functions work as documented
- [ ] Hooks/filters fire correctly
- [ ] External plugin integration tested

**For developer API updates:**
- [ ] Backward compatibility maintained
- [ ] Existing integrations still work
- [ ] New functionality accessible

**General testing:**
- [ ] No console errors
- [ ] Tested in wp-env environment
- [ ] Works across different WordPress blocks

## Screenshots

<!-- Add screenshots showing before/after or new functionality -->

## Developer API Impact _(if applicable)_

- [ ] No API changes
- [ ] New hooks/filters added
- [ ] Breaking changes to existing API
- [ ] Documentation updated

## Checklist

- [ ] Code follows WordPress standards
- [ ] No PHP/JavaScript errors
- [ ] Tested in wp-env environment
- [ ] Documentation updated (if needed)