### PR TITLE
docs: updated to reflect fallbacks when ba11y plugin is not active

### DIFF
--- a/docs/block-validation/javascript.md
+++ b/docs/block-validation/javascript.md
@@ -155,22 +155,33 @@ addFilter(
 
 ## Enqueuing Your Script
 
-Your validation script must be loaded in the block editor with the correct dependencies:
+Your validation script must be loaded in the block editor. For better compatibility, conditionally add the dependency:
 
 ```php
 function my_plugin_enqueue_accessibility_assets() {
+    $asset_file = include plugin_dir_path( __FILE__ ) . 'build/a11y-checks.asset.php';
+    
+    // Start with base dependencies
+    $dependencies = $asset_file['dependencies'];
+    
+    // Only add Block Accessibility Checks plugin as a dependency if it's active.
+    // This allows your plugin to work even when the Block Accessibility Checks plugin is deactivated.
+    if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+        $dependencies[] = 'block-accessibility-script';
+    }
+
     wp_enqueue_script(
         'my-plugin-accessibility-checks',
         plugins_url( 'build/a11y-checks.js', __FILE__ ),
-        array( 'wp-hooks', 'wp-i18n', 'block-accessibility-script' ),
-        '1.0.0',
+        $dependencies,
+        isset( $asset_file['version'] ) ? $asset_file['version'] : '1.0.0',
         true
     );
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_enqueue_accessibility_assets' );
 ```
 
-**Important:** Include `'block-accessibility-script'` as a dependency to ensure the validation system is loaded first.
+**Important:** Include `'block-accessibility-script'` as a dependency (when available) to ensure the validation system is loaded first. If the plugin is not active, your script will still load but validation will not work.
 
 ## How Validation Works
 

--- a/docs/editor-validation/javascript.md
+++ b/docs/editor-validation/javascript.md
@@ -201,22 +201,33 @@ addFilter(
 
 ## Enqueuing Your Script
 
-Your validation script must be loaded in the block editor with the correct dependencies:
+Your validation script must be loaded in the block editor. For better compatibility, conditionally add the dependency:
 
 ```php
 function my_plugin_enqueue_editor_validation() {
+    $asset_file = include plugin_dir_path( __FILE__ ) . 'build/editor-validation.asset.php';
+    
+    // Start with base dependencies
+    $dependencies = $asset_file['dependencies'];
+    
+    // Only add Block Accessibility Checks plugin as a dependency if it's active.
+    // This allows your plugin to work even when the Block Accessibility Checks plugin is deactivated.
+    if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+        $dependencies[] = 'block-accessibility-script';
+    }
+
     wp_enqueue_script(
         'my-plugin-editor-validation',
         plugins_url( 'build/editor-validation.js', __FILE__ ),
-        array( 'wp-hooks', 'wp-i18n', 'block-accessibility-script' ),
-        '1.0.0',
+        $dependencies,
+        isset( $asset_file['version'] ) ? $asset_file['version'] : '1.0.0',
         true
     );
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_enqueue_editor_validation' );
 ```
 
-**Important:** Include `'block-accessibility-script'` as a dependency to ensure the validation system is loaded first.
+**Important:** Include `'block-accessibility-script'` as a dependency (when available) to ensure the validation system is loaded first. If the plugin is not active, your script will still load but validation will not work.
 
 ## How Validation Works
 

--- a/docs/editor-validation/quick-start.md
+++ b/docs/editor-validation/quick-start.md
@@ -61,18 +61,28 @@ Your validation logic must be loaded in the block editor:
 
 ```php
 function my_plugin_enqueue_editor_validation() {
+    $asset_file = include plugin_dir_path( __FILE__ ) . 'build/editor-validation.asset.php';
+    
+    // Start with base dependencies
+    $dependencies = $asset_file['dependencies'];
+    
+    // Only add Block Accessibility Checks plugin as a dependency if it's active.
+    if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+        $dependencies[] = 'block-accessibility-script';
+    }
+
     wp_enqueue_script(
         'my-plugin-editor-validation',
         plugins_url( 'build/editor-validation.js', __FILE__ ),
-        array( 'wp-hooks', 'wp-i18n', 'block-accessibility-script' ),
-        '1.0.0',
+        $dependencies,
+        isset( $asset_file['version'] ) ? $asset_file['version'] : '1.0.0',
         true
     );
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_enqueue_editor_validation' );
 ```
 
-**Important:** Include `'block-accessibility-script'` as a dependency.
+**Important:** Conditionally including the dependency allows your plugin to work even when the Block Accessibility Checks plugin is deactivated.
 
 ## Common Use Cases
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -111,19 +111,28 @@ addFilter(
 
 **PHP:**
 ```php
-use BlockAccessibility\MetaValidation;
-
 add_action( 'init', function() {
+    // Check if Validator class is available (plugin may be deactivated)
+    $validator_class = '\BlockAccessibility\Meta\Validator';
+    $validator_available = class_exists( $validator_class );
+
     register_post_meta( 'band', 'band_origin', [
         'single'            => true,
         'type'              => 'string',
         'show_in_rest'      => true,
         'sanitize_callback' => 'sanitize_text_field',
-        'validate_callback' => MetaValidation::required( 'band', 'band_origin', [
-            'error_msg'   => __( 'City of Origin is required.', 'my-plugin' ),
-            'warning_msg' => __( 'City of Origin is recommended.', 'my-plugin' ),
-            'type'        => 'settings',
-        ]),
+        'validate_callback' => $validator_available
+            ? call_user_func(
+                array( $validator_class, 'required' ),
+                'band',
+                'band_origin',
+                [
+                    'error_msg'   => __( 'City of Origin is required.', 'my-plugin' ),
+                    'warning_msg' => __( 'City of Origin is recommended.', 'my-plugin' ),
+                    'type'        => 'settings',
+                ]
+            )
+            : null,
     ]);
 });
 ```
@@ -152,17 +161,25 @@ addFilter(
 
 **PHP:**
 ```php
-use BlockAccessibility\MetaValidation;
+$validator_class = '\BlockAccessibility\Meta\Validator';
+$validator_available = class_exists( $validator_class );
 
 register_post_meta( 'band', 'band_start_date', [
     'single'            => true,
     'type'              => 'string',
     'show_in_rest'      => true,
     'sanitize_callback' => 'sanitize_text_field',
-    'validate_callback' => MetaValidation::required( 'band', 'band_start_date', [
-        'error_msg' => __( 'Start date is required and must be in YYYY-MM-DD format.', 'my-plugin' ),
-        'type'      => 'error',
-    ]),
+    'validate_callback' => $validator_available
+        ? call_user_func(
+            array( $validator_class, 'required' ),
+            'band',
+            'band_start_date',
+            [
+                'error_msg' => __( 'Start date is required and must be in YYYY-MM-DD format.', 'my-plugin' ),
+                'type'      => 'error',
+            ]
+        )
+        : null,
 ]);
 ```
 
@@ -332,8 +349,6 @@ A complete example showing all three validation systems working together:
 
 **PHP:**
 ```php
-use BlockAccessibility\MetaValidation;
-
 // Block check
 add_action( 'ba11yc_ready', function( $registry ) {
     $registry->register_check( 'my-plugin/card', 'has_title', [
@@ -343,11 +358,21 @@ add_action( 'ba11yc_ready', function( $registry ) {
 } );
 
 // Meta check
+$validator_class = '\BlockAccessibility\Meta\Validator';
+$validator_available = class_exists( $validator_class );
+
 register_post_meta( 'post', 'card_category', [
-    'validate_callback' => MetaValidation::required( 'post', 'card_category', [
-        'error_msg' => 'Category is required.',
-        'type'      => 'error',
-    ]),
+    'validate_callback' => $validator_available
+        ? call_user_func(
+            array( $validator_class, 'required' ),
+            'post',
+            'card_category',
+            [
+                'error_msg' => 'Category is required.',
+                'type'      => 'error',
+            ]
+        )
+        : null,
 ] );
 
 // Editor check

--- a/docs/integration/external-plugins.md
+++ b/docs/integration/external-plugins.md
@@ -135,11 +135,22 @@ class MyCustomBlocksIntegration {
     }
 
     public function enqueue_validation_script() {
+        $asset_file = include plugin_dir_path( __FILE__ ) . 'build/validation.asset.php';
+        
+        // Start with base dependencies
+        $dependencies = $asset_file['dependencies'];
+        
+        // Only add Block Accessibility Checks plugin as a dependency if it's active.
+        // This allows your plugin to work even when the Block Accessibility Checks plugin is deactivated.
+        if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+            $dependencies[] = 'block-accessibility-script';
+        }
+
         wp_enqueue_script(
             'my-custom-blocks-validation',
             plugins_url( 'build/validation.js', __FILE__ ),
-            array( 'wp-hooks', 'wp-i18n', 'block-accessibility-script' ),
-            '1.0.0',
+            $dependencies,
+            isset( $asset_file['version'] ) ? $asset_file['version'] : '1.0.0',
             true
         );
     }

--- a/docs/meta-validation/javascript.md
+++ b/docs/meta-validation/javascript.md
@@ -85,14 +85,19 @@ The plugin provides a `useMetaField` hook to automatically handle state and vali
 
 ### Script Dependencies
 
-When using the validation hook, ensure your script has the Block Accessibility Checks script as a dependency:
+When using the validation hook, you should conditionally add the Block Accessibility Checks script as a dependency to allow your plugin to work even when the Block Accessibility Checks plugin is deactivated:
 
 ```php
-// Add 'block-accessibility-script' as a dependency
-$dependencies = array_merge(
-    $asset_file['dependencies'],
-    array( 'block-accessibility-script' )
-);
+$asset_file = include plugin_dir_path( __FILE__ ) . 'build/my-script.asset.php';
+
+// Start with base dependencies
+$dependencies = $asset_file['dependencies'];
+
+// Only add Block Accessibility Checks plugin as a dependency if it's active.
+// This allows your sidebar/UI to work even when the plugin is deactivated.
+if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+    $dependencies[] = 'block-accessibility-script';
+}
 
 wp_enqueue_script(
     'my-script-handle',
@@ -102,6 +107,8 @@ wp_enqueue_script(
     false
 );
 ```
+
+**Note:** If the Block Accessibility Checks plugin is not active, validation will not work, but your UI components (like sidebars) will still function. The `useMetaField` hook includes a fallback that works without the plugin.
 
 Then access the hook with a defensive check:
 

--- a/docs/meta-validation/php.md
+++ b/docs/meta-validation/php.md
@@ -11,23 +11,34 @@ PHP is used to register meta checks, configure metadata, and integrate with Word
 The easiest way to add meta validation is using the `MetaValidation::required()` helper method:
 
 ```php
-use BlockAccessibility\MetaValidation;
-
 add_action( 'init', function() {
+    // Check if Validator class is available (plugin may be deactivated)
+    $validator_class = '\BlockAccessibility\Meta\Validator';
+    $validator_available = class_exists( $validator_class );
+
     register_post_meta( 'band', 'band_origin', [
         'single'            => true,
         'type'              => 'string',
         'show_in_rest'      => true,
         'sanitize_callback' => 'sanitize_text_field',
-        'validate_callback' => MetaValidation::required( 'band', 'band_origin', [
-            'error_msg'   => __( 'City of Origin is required.', 'my-plugin' ),
-            'warning_msg' => __( 'City of Origin is recommended.', 'my-plugin' ),
-            'description' => __( 'The city where the band originated', 'my-plugin' ),
-            'type'        => 'settings',
-        ]),
+        'validate_callback' => $validator_available
+            ? call_user_func(
+                array( $validator_class, 'required' ),
+                'band',
+                'band_origin',
+                [
+                    'error_msg'   => __( 'City of Origin is required.', 'my-plugin' ),
+                    'warning_msg' => __( 'City of Origin is recommended.', 'my-plugin' ),
+                    'description' => __( 'The city where the band originated', 'my-plugin' ),
+                    'type'        => 'settings',
+                ]
+            )
+            : null,
     ]);
 });
 ```
+
+**Note:** The conditional check ensures your plugin continues to work even if the Block Accessibility Checks plugin is deactivated. The meta field will still be registered, but validation will be disabled.
 
 ### How MetaValidation::required() Works
 
@@ -116,49 +127,77 @@ Meta validation checks appear in the admin settings UI alongside block checks:
 ### Required Field with Settings Control
 
 ```php
-use BlockAccessibility\MetaValidation;
+$validator_class = '\BlockAccessibility\Meta\Validator';
+$validator_available = class_exists( $validator_class );
 
 register_post_meta( 'band', 'band_origin', [
     'single'            => true,
     'type'              => 'string',
     'show_in_rest'      => true,
     'sanitize_callback' => 'sanitize_text_field',
-    'validate_callback' => MetaValidation::required( 'band', 'band_origin', [
-        'error_msg'   => __( 'City of Origin is required.', 'my-plugin' ),
-        'warning_msg' => __( 'City of Origin is recommended.', 'my-plugin' ),
-        'description' => __( 'The city where the band originated', 'my-plugin' ),
-        'type'        => 'settings',
-    ]),
+    'validate_callback' => $validator_available
+        ? call_user_func(
+            array( $validator_class, 'required' ),
+            'band',
+            'band_origin',
+            [
+                'error_msg'   => __( 'City of Origin is required.', 'my-plugin' ),
+                'warning_msg' => __( 'City of Origin is recommended.', 'my-plugin' ),
+                'description' => __( 'The city where the band originated', 'my-plugin' ),
+                'type'        => 'settings',
+            ]
+        )
+        : null,
 ]);
 ```
 
 ### Always an Error (Not Configurable)
 
 ```php
+$validator_class = '\BlockAccessibility\Meta\Validator';
+$validator_available = class_exists( $validator_class );
+
 register_post_meta( 'band', 'band_name', [
     'single'            => true,
     'type'              => 'string',
     'show_in_rest'      => true,
     'sanitize_callback' => 'sanitize_text_field',
-    'validate_callback' => MetaValidation::required( 'band', 'band_name', [
-        'error_msg' => __( 'Band name is required.', 'my-plugin' ),
-        'type'      => 'error',
-    ]),
+    'validate_callback' => $validator_available
+        ? call_user_func(
+            array( $validator_class, 'required' ),
+            'band',
+            'band_name',
+            [
+                'error_msg' => __( 'Band name is required.', 'my-plugin' ),
+                'type'      => 'error',
+            ]
+        )
+        : null,
 ]);
 ```
 
 ### Always a Warning (Not Configurable)
 
 ```php
+$validator_class = '\BlockAccessibility\Meta\Validator';
+$validator_available = class_exists( $validator_class );
+
 register_post_meta( 'band', 'band_website', [
     'single'            => true,
     'type'              => 'string',
     'show_in_rest'      => true,
     'sanitize_callback' => 'esc_url_raw',
-    'validate_callback' => MetaValidation::required( 'band', 'band_website', [
-        'error_msg' => __( 'Band website is recommended.', 'my-plugin' ),
-        'type'      => 'warning',
-    ]),
+    'validate_callback' => $validator_available
+        ? call_user_func(
+            array( $validator_class, 'required' ),
+            'band',
+            'band_website',
+            [
+                'error_msg' => __( 'Band website is recommended.', 'my-plugin' ),
+                'type'      => 'warning',
+            ]
+        )
+        : null,
 ]);
 ```
 

--- a/docs/meta-validation/quick-start.md
+++ b/docs/meta-validation/quick-start.md
@@ -11,23 +11,34 @@ Post meta validation allows you to validate WordPress post meta fields with the 
 Here's the simplest way to add validation to a post meta field:
 
 ```php
-use BlockAccessibility\MetaValidation;
-
 add_action( 'init', function() {
+    // Check if Validator class is available (plugin may be deactivated)
+    $validator_class = '\BlockAccessibility\Meta\Validator';
+    $validator_available = class_exists( $validator_class );
+
     register_post_meta( 'band', 'band_origin', [
         'single'            => true,
         'type'              => 'string',
         'show_in_rest'      => true,
         'sanitize_callback' => 'sanitize_text_field',
-        'validate_callback' => MetaValidation::required( 'band', 'band_origin', [
-            'error_msg' => __( 'City of Origin is required.', 'my-plugin' ),
-            'type'      => 'settings',
-        ]),
+        'validate_callback' => $validator_available
+            ? call_user_func(
+                array( $validator_class, 'required' ),
+                'band',
+                'band_origin',
+                [
+                    'error_msg' => __( 'City of Origin is required.', 'my-plugin' ),
+                    'type'      => 'settings',
+                ]
+            )
+            : null,
     ]);
 });
 ```
 
-That's it! The `MetaValidation::required()` method handles:
+**Note:** The conditional check ensures your plugin continues to work even if the Block Accessibility Checks plugin is deactivated.
+
+That's it! The `Validator::required()` method handles:
 - ✅ Registering the validation check
 - ✅ Integrating with settings UI
 - ✅ Server-side validation

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,13 @@ This guide covers common issues, debugging tips, and solutions for developers in
 **Problem:** Your validation logic is not being called.
 
 **Solution:**
-- Confirm your script is enqueued with the correct dependencies (`block-accessibility-script`)
+- Confirm your script is enqueued with the correct dependencies
+- **For better compatibility:** Conditionally add `'block-accessibility-script'` only if it's registered:
+  ```php
+  if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+      $dependencies[] = 'block-accessibility-script';
+  }
+  ```
 - Use the `enqueue_block_editor_assets` action
 - Check for typos in block type and check name
 - Verify the check is registered in PHP
@@ -53,8 +59,12 @@ This guide covers common issues, debugging tips, and solutions for developers in
 **Solution:**
 - Ensure `type` is set to `'settings'` in the check configuration
 - Verify the check is being registered (check PHP errors)
+- **If the Block Accessibility Checks plugin is deactivated:** Use conditional checks:
+  ```php
+  $validator_class = '\BlockAccessibility\Meta\Validator';
+  $validator_available = class_exists( $validator_class );
+  ```
 - Clear WordPress cache and reload admin page
-- Check that `MetaValidation::required()` was called correctly
 
 #### Validation Not Working
 **Problem:** Meta field validation doesn't work in the editor.
@@ -79,11 +89,17 @@ This guide covers common issues, debugging tips, and solutions for developers in
 **Problem:** `MetaField` or `ValidatedToolsPanelItem` don't show validation.
 
 **Solution:**
-- Ensure `'block-accessibility-script'` is included as a dependency
+- **For better compatibility:** Conditionally add `'block-accessibility-script'` only if it's registered:
+  ```php
+  if ( wp_script_is( 'block-accessibility-script', 'registered' ) ) {
+      $dependencies[] = 'block-accessibility-script';
+  }
+  ```
 - Check that components are accessed correctly: `window.BlockAccessibilityChecks?.MetaField`
 - Verify the `metaKey` prop matches the registered meta key
 - Check browser console for JavaScript errors
 - Check the Unified Sidebar (click accessibility icon in header) to see if errors are reported there
+- **Note:** If the Block Accessibility Checks plugin is not active, the `useMetaField` hook includes a fallback that works without the plugin
 
 
 ### Editor Validation


### PR DESCRIPTION
# Pull Request

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New accessibility check
- [ ] 🔌 New developer API feature
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ♿ Accessibility improvement
- [ ] 💥 Breaking change

## Related Issues

Related issue(s): #{add issue}

## Changes Made

<!-- List the main changes -->

- 
- 

## Testing

**Environment:**
- WordPress Version:
- Browser(s) tested:

**Test Cases:** _(check what applies to your change)_

**For new accessibility checks:**
- [ ] Tested error state (red border/message)
- [ ] Tested warning state (yellow border/message)
- [ ] Tested valid state (no indicators)
- [ ] Publishing prevention works (for errors)

**For updated accessibility checks:**
- [ ] Existing functionality still works
- [ ] New behavior works as expected
- [ ] No regressions in other blocks

**For new developer API features:**
- [ ] API functions work as documented
- [ ] Hooks/filters fire correctly
- [ ] External plugin integration tested

**For developer API updates:**
- [ ] Backward compatibility maintained
- [ ] Existing integrations still work
- [ ] New functionality accessible

**General testing:**
- [ ] No console errors
- [ ] Tested in wp-env environment
- [ ] Works across different WordPress blocks

## Screenshots

<!-- Add screenshots showing before/after or new functionality -->

## Developer API Impact _(if applicable)_

- [ ] No API changes
- [ ] New hooks/filters added
- [ ] Breaking changes to existing API
- [ ] Documentation updated

## Checklist

- [ ] Code follows WordPress standards
- [ ] No PHP/JavaScript errors
- [ ] Tested in wp-env environment
- [ ] Documentation updated (if needed)