### PR TITLE
added support for using an array of blocks in individual heading hierachy validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [Unreleased]
+
+### Added
+
+- `ba11yc_register_heading_source()` accepts an array of block types as its first argument, applying one spec to every block in the list. A block library where many blocks share the same heading shape no longer needs a separate call per block. Passing a single block type string still works, and every spec shape — `level`, `attribute`, `map`, `requires`, and a `headings` list — behaves the same either way
+
 ## [4.2.1]
 
 ### Changed

--- a/block-accessibility-checks.php
+++ b/block-accessibility-checks.php
@@ -214,23 +214,38 @@ function ba11yc_register_editor_check( string $post_type, array $args ): bool {
  *         'requires' => 'title',
  *     ) );
  *
+ *     // Several blocks that share the same heading shape.
+ *     ba11yc_register_heading_source(
+ *         array( 'acme/hero', 'acme/card-list' ),
+ *         array(
+ *             'attribute' => 'headingLevel',
+ *             'level'     => 2,
+ *         )
+ *     );
+ *
  * @since 4.2.0
  *
- * @param string $block_type Block type name (e.g. 'acme/section').
- * @param array  $args       Heading spec. Optional keys: 'level' (0-6, where 0
- *                           means the block renders no heading), 'attribute'
- *                           (attribute holding the level), 'map' (translates
- *                           attribute values to levels), 'requires' (attribute
- *                           that must have content for the heading to exist).
- *                           Pass a list under 'headings' for a block that
- *                           renders more than one.
- * @return bool True on success, false on failure.
+ * @param string|array $block_types Block type name (e.g. 'acme/section'), or an
+ *                                  array of block type names sharing one spec.
+ * @param array        $args        Heading spec. Optional keys: 'level' (0-6, where 0
+ *                                  means the block renders no heading), 'attribute'
+ *                                  (attribute holding the level), 'map' (translates
+ *                                  attribute values to levels), 'requires' (attribute
+ *                                  that must have content for the heading to exist).
+ *                                  Pass a list under 'headings' for a block that
+ *                                  renders more than one.
+ * @return bool True on success, false if any block type failed to register.
  */
-function ba11yc_register_heading_source( string $block_type, array $args ): bool {
-	if ( empty( $block_type ) ) {
+function ba11yc_register_heading_source( $block_types, array $args ): bool {
+	if ( ! is_string( $block_types ) && ! is_array( $block_types ) ) {
+		\_doing_it_wrong( __FUNCTION__, \esc_html__( 'A block type string or array of block types is required.', 'block-accessibility-checks' ), '4.2.0' );
+		return false;
+	}
+
+	if ( empty( $block_types ) ) {
 		\_doing_it_wrong( __FUNCTION__, \esc_html__( 'A block type is required.', 'block-accessibility-checks' ), '4.2.0' );
 		return false;
 	}
 
-	return \BlockAccessibility\Block\HeadingSources::get_instance()->register_source( $block_type, $args );
+	return \BlockAccessibility\Block\HeadingSources::get_instance()->register_source( $block_types, $args );
 }

--- a/docs/integration/external-plugins.md
+++ b/docs/integration/external-plugins.md
@@ -144,6 +144,15 @@ add_action( 'ba11yc_ready', function () {
     // The block renders no heading. Also useful to exclude a block that would
     // otherwise be detected.
     ba11yc_register_heading_source( 'my-plugin/quiet', array( 'level' => 0 ) );
+
+    // Several blocks sharing one shape — the common case in a block library.
+    ba11yc_register_heading_source(
+        array( 'my-plugin/hero', 'my-plugin/card-list' ),
+        array(
+            'attribute' => 'headingLevel',
+            'level'     => 2,
+        )
+    );
 } );
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -111,7 +111,7 @@ Register a document-level validation check for a post type.
 
 ---
 
-### `ba11yc_register_heading_source( $block_type, $args )`
+### `ba11yc_register_heading_source( $block_types, $args )`
 
 Declares that a block type renders a heading, so the heading order check counts it.
 
@@ -121,6 +121,10 @@ else — including blocks whose `block.json` you do not control.
 
 **Parameters**
 
+`$block_types` accepts a single block type name, or an array of names that share one spec.
+
+`$args` is the spec itself:
+
 | Key         | Type     | Description                                                                                       |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `level`     | int      | The heading level, 0-6. `0` means the block renders no heading. Defaults to `2`.                   |
@@ -129,7 +133,8 @@ else — including blocks whose `block.json` you do not control.
 | `requires`  | string   | Attribute that must have content for the heading to exist at all.                                  |
 | `headings`  | array    | A list of the above, for a block that renders more than one heading.                               |
 
-Returns `true` on success, `false` on failure.
+Returns `true` on success, `false` if any block type failed to register. Entries that are not
+non-empty strings are skipped and logged; the rest still register.
 
 **Examples**
 
@@ -160,8 +165,19 @@ add_action( 'ba11yc_ready', function () {
 
     // The block renders no heading at all.
     ba11yc_register_heading_source( 'acme/quiet', array( 'level' => 0 ) );
+
+    // Several blocks that share the same heading shape.
+    ba11yc_register_heading_source(
+        array( 'acme/hero', 'acme/card-list', 'acme/feature' ),
+        array(
+            'attribute' => 'headingLevel',
+            'level'     => 2,
+        )
+    );
 } );
 ```
+
+Any spec shape works with an array, since the spec is resolved once and applied to each block.
 
 The spec is data rather than a callback because the check runs live in the editor, in JavaScript.
 For a level that cannot be expressed this way — derived from nesting depth, from sibling state, or

--- a/includes/Block/HeadingSources.php
+++ b/includes/Block/HeadingSources.php
@@ -107,49 +107,83 @@ class HeadingSources {
 	}
 
 	/**
-	 * Register a heading source for a block type.
+	 * Register a heading source for one or more block types.
 	 *
-	 * @param string $block_type Block type name (e.g. 'acme/section').
-	 * @param array  $args       Heading spec, or a list of specs under 'headings'.
-	 * @return bool True when the source was stored.
+	 * Passing several block types applies the same spec to each, which is the
+	 * common case in a block library where many blocks share a heading shape.
+	 *
+	 * @param string|array $block_types Block type name, or a list of them.
+	 * @param array        $args        Heading spec, or a list of specs under 'headings'.
+	 * @return bool True when every block type was stored.
 	 */
-	public function register_source( string $block_type, array $args ): bool {
-		if ( '' === $block_type ) {
-			$this->log_error( 'A block type is required to register a heading source.' );
+	public function register_source( $block_types, array $args ): bool {
+		$requested = is_array( $block_types ) ? $block_types : array( $block_types );
+		$valid     = array();
+
+		foreach ( $requested as $block_type ) {
+			if ( ! is_string( $block_type ) || '' === $block_type ) {
+				$this->log_error( 'A block type must be a non-empty string to register a heading source.' );
+				continue;
+			}
+
+			$valid[] = $block_type;
+		}
+
+		if ( empty( $valid ) ) {
 			return false;
 		}
 
 		$raw = isset( $args['headings'] ) ? $args['headings'] : $args;
 
-		$spec = $this->normalize( $raw, $block_type );
+		// Normalized once and shared. Passing every block type as the log
+		// context means a malformed spec is reported once, naming all of the
+		// blocks it would have affected, rather than once per block.
+		$spec = $this->normalize( $raw, implode( ', ', $valid ) );
 
 		if ( null === $spec ) {
 			return false;
 		}
 
-		$this->registered[ $block_type ] = $spec;
+		// Arrays are copied on assignment, so the blocks cannot end up sharing
+		// a mutable spec.
+		foreach ( $valid as $block_type ) {
+			$this->registered[ $block_type ] = $spec;
+		}
 
 		// Sources may be registered after a read in long-running requests.
 		$this->resolved = null;
 
-		return true;
+		// Anything skipped above was logged; report it rather than swallowing
+		// a typo in one entry of an otherwise good list.
+		return count( $valid ) === count( $requested );
 	}
 
 	/**
-	 * Remove a registered heading source.
+	 * Remove one or more registered heading sources.
 	 *
-	 * @param string $block_type Block type name.
-	 * @return bool True when a source was removed.
+	 * @param string|array $block_types Block type name, or a list of them.
+	 * @return bool True when every named source was found and removed.
 	 */
-	public function unregister_source( string $block_type ): bool {
-		if ( ! isset( $this->registered[ $block_type ] ) ) {
+	public function unregister_source( $block_types ): bool {
+		$requested = is_array( $block_types ) ? $block_types : array( $block_types );
+		$removed   = 0;
+
+		foreach ( $requested as $block_type ) {
+			if ( ! is_string( $block_type ) || ! isset( $this->registered[ $block_type ] ) ) {
+				continue;
+			}
+
+			unset( $this->registered[ $block_type ] );
+			++$removed;
+		}
+
+		if ( 0 === $removed ) {
 			return false;
 		}
 
-		unset( $this->registered[ $block_type ] );
 		$this->resolved = null;
 
-		return true;
+		return count( $requested ) === $removed;
 	}
 
 	/**


### PR DESCRIPTION
Added array support to `ba11yc_register_heading_source()` in `fe9ab5c`.

The first argument now takes a string or an array, so blocks sharing a heading shape can register in one call:

```php
ba11yc_register_heading_source(
    array( 'my-plugin/hero', 'my-plugin/card-list' ),
    array( 'attribute' => 'headingLevel', 'level' => 2 )
);
```